### PR TITLE
Fixes a bug where the connection would timeout.

### DIFF
--- a/smtpevent.js
+++ b/smtpevent.js
@@ -182,11 +182,6 @@ var SMTPConnection = function (hostname, server, socket) {
     }
         
     // Event listeners:
-    socket.on('connect', function () {
-        util.log('Socket connected from: ' + socket.remoteAddress + '. Sending welcome message.');
-        send_response('220 ' + hostname +' node.js smtpevent server ' + server.version);
-    });
-    
     socket.on('data', function (buffer) {
         var line = buffer.toString(),
             method = null,
@@ -262,6 +257,9 @@ var SMTPConnection = function (hostname, server, socket) {
         util.log('Socket closed, destroying SMTPConnection instance');
         delete self;
     });
+    
+    util.log('Socket connected from: ' + socket.remoteAddress + '. Sending welcome message.');
+    send_response('220 ' + hostname +' node.js smtpevent server ' + server.version);
 }
     
 sys.inherits(SMTPServer, net.Server);


### PR DESCRIPTION
In NodeJS 0.10.3 the socket connect event would never fire. Which meant the smtp server greeting would not be sent to the client and the smtp session would not progress. As soon as the server creates the socket you can read from/write to it, you dont need to wait for a connect event, which in 0.10.3 doesnt fire anyway.
